### PR TITLE
Fix visualizer return type

### DIFF
--- a/src/exergy_dashboard/visualization.py
+++ b/src/exergy_dashboard/visualization.py
@@ -47,7 +47,7 @@ Examples
     ```
 """
 
-from typing import Callable, Dict, List, Any
+from typing import Callable, Dict, List, Any, Optional
 import streamlit as st
 from dataclasses import dataclass
 
@@ -86,9 +86,9 @@ class VisualizationRegistry:
             return func
         return decorator
     
-    def get_visualizer(self, name: str, mode: str) -> Callable:
+    def get_visualizer(self, name: str, mode: str) -> Optional[Callable]:
         """
-        시각화 도구 함수를 반환
+        시각화 도구 함수를 반환합니다. 존재하지 않으면 ``None``을 반환합니다.
 
         Parameters
         ----------
@@ -99,8 +99,8 @@ class VisualizationRegistry:
 
         Returns
         -------
-        Callable
-            시각화 함수
+        Optional[Callable]
+            시각화 함수. 시각화가 존재하지 않으면 ``None``을 반환합니다.
         """
         if mode in self._visualizers and name in self._visualizers[mode]:
             return self._visualizers[mode][name]


### PR DESCRIPTION
## Summary
- allow `get_visualizer` to return `None`
- document the possibility of missing visualizers

## Testing
- `python -m py_compile src/exergy_dashboard/visualization.py`

------
https://chatgpt.com/codex/tasks/task_e_687bd26682e48323b26afdf42efb5dc5