### PR TITLE
Add registry unit tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on the path so tests can import the package
+SRC_PATH = Path(__file__).resolve().parents[1] / 'src'
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+import types
+if 'streamlit' not in sys.modules:
+    st_stub = types.ModuleType('streamlit')
+    st_stub.tabs = lambda *args, **kwargs: []
+    st_stub.subheader = lambda *args, **kwargs: None
+    st_stub.write = lambda *args, **kwargs: None
+    st_stub.altair_chart = lambda *args, **kwargs: None
+    st_stub.error = lambda *args, **kwargs: None
+    sys.modules['streamlit'] = st_stub

--- a/tests/test_evaluation_registry.py
+++ b/tests/test_evaluation_registry.py
@@ -1,0 +1,16 @@
+import pytest
+from exergy_dashboard.evaluation import EvaluationRegistry
+
+
+def test_register_and_evaluate_dummy():
+    registry = EvaluationRegistry()
+
+    @registry.register('TEST', 'DUMMY')
+    def dummy(params):
+        return {'value': params['a'] + params['b']}
+
+    evaluator = registry.get_evaluator('TEST', 'DUMMY')
+    assert evaluator is dummy
+
+    result = registry.evaluate('TEST', 'DUMMY', {'a': 1, 'b': 2})
+    assert result == {'value': 3}

--- a/tests/test_visualization_registry.py
+++ b/tests/test_visualization_registry.py
@@ -1,0 +1,15 @@
+from exergy_dashboard.visualization import VisualizationRegistry
+
+
+def test_register_and_get_visualizer():
+    registry = VisualizationRegistry()
+
+    @registry.register('TEST', 'dummy')
+    def dummy_visualizer(ss, systems):
+        return 'ok'
+
+    func = registry.get_visualizer('dummy', 'TEST')
+    assert func is dummy_visualizer
+    assert func(None, []) == 'ok'
+
+    assert registry.get_visualizer('unknown', 'TEST') is None


### PR DESCRIPTION
## Summary
- add new `tests` package and update PYTHONPATH for unit tests
- stub out `streamlit` to allow imports
- test `EvaluationRegistry` registration and evaluation
- test `VisualizationRegistry` registration and retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd2bf3ab0832395e26a4b101adbe7